### PR TITLE
Update login page title to Abacus

### DIFF
--- a/src/components/auth-page/index.tsx
+++ b/src/components/auth-page/index.tsx
@@ -6,6 +6,7 @@ export const AuthPage = (props: AuthPageProps) => {
   return (
     <AuthPageBase
       {...props}
+      title="Abacus"
       formProps={{
         initialValues: {
           email: "",


### PR DESCRIPTION
The login page title was previously "Refine Project". This change updates the title to "Abacus" by passing the `title` prop to the `AuthPageBase` component in `src/components/auth-page/index.tsx`.